### PR TITLE
Update first_phase_rename_hardware.php

### DIFF
--- a/hardware_taxonomy/first_phase_rename_hardware.php
+++ b/hardware_taxonomy/first_phase_rename_hardware.php
@@ -5,6 +5,7 @@ $terms = array(
 	59 => 'Business Computer',
 	60 => 'Calculator',
 	61 => 'Computer Case',
+	
 	62 => 'CPUs',
 	63 => 'Data Collection',
 	64 => 'Desktop Computer',


### PR DESCRIPTION
- Actual structure: 
```
  GTX_Patient_Information:
    gtxpatientdetails:
      zipcode:
      ....
```
needed structure: 
```
  patient:
    zipcode:
    ....
```    
Why is the `gtxpatientdetails` needed? Can it be deleted?

- We should stick to a single naming convention and not mix PascalCase, camelCase, snake_case and kebab-case (e.g. `zipcode` -> `zipCode`).

- Can `dateofbirth` be renamed to `birthDate`? 

- On the enrollment form, there is only one address field. Is it possible to remove `address2` and `address3`?

Actual structure: 
```
  address1: Test Address
  address2: yuiaddress2
  address3: testingaddress3
```
needed structure: 
```
  address: Test Address
```    

- Use State Code instead of State Name

Actual
```
state: Alaska
```
needed
```
state: AL
```

- Rename `phonenumber` to `phone`

- Rename `preffereccomchannel` to `communicationChannel`

- Rename `besttimetocontact` to `contactTime`



